### PR TITLE
Fix displayAs support for detail and index

### DIFF
--- a/resources/js/components/DetailField.vue
+++ b/resources/js/components/DetailField.vue
@@ -17,10 +17,10 @@
         props: ['resource', 'resourceName', 'resourceId', 'field'],
         mounted() {
             vm = this;
-            this.fieldLabel = this.field;
-            let items = this.field.value || this.field.displayedAs;
+            this.fieldLabel = { ...this.field };
+            let items = this.fieldLabel.value || this.fieldLabel.displayedAs;
 
-            if (items) {
+            if (items instanceof Array && items.length) {
                 items.forEach(function (item, index) {
                     // Backward compatibility in case tags are stored as object
                     let label = (typeof item === "object" && item.hasOwnProperty('text')) ? item.text : item;
@@ -28,8 +28,10 @@
                 });
 
                 this.fieldLabel.value = '<div class="' + this.tagsWrapperClass + '">' + this.tags + '</div>';
-                this.field.displayedAs = this.field.value;
+                this.fieldLabel.displayedAs = this.field.value;
                 this.fieldLabel.asHtml = true; // displays as html in the PanelItem component
+            } else {
+                this.fieldLabel.displayedAs = this.fieldLabel.displayedAs || '—';
             }
         }
     }

--- a/resources/js/components/DetailField.vue
+++ b/resources/js/components/DetailField.vue
@@ -18,9 +18,9 @@
         mounted() {
             vm = this;
             this.fieldLabel = this.field;
+            let items = this.field.value || this.field.displayedAs;
 
-            if (this.field.value) {
-                let items = this.field.value;
+            if (items) {
                 items.forEach(function (item, index) {
                     // Backward compatibility in case tags are stored as object
                     let label = (typeof item === "object" && item.hasOwnProperty('text')) ? item.text : item;
@@ -28,6 +28,7 @@
                 });
 
                 this.fieldLabel.value = '<div class="' + this.tagsWrapperClass + '">' + this.tags + '</div>';
+                this.field.displayedAs = this.field.value;
                 this.fieldLabel.asHtml = true; // displays as html in the PanelItem component
             }
         }

--- a/resources/js/components/IndexField.vue
+++ b/resources/js/components/IndexField.vue
@@ -9,7 +9,7 @@
         data() {
             return {
                 tags: '',
-                fieldLabel: '',
+                fieldLabel: this.field.value || this.field.displayedAs || '—',
                 tagsWrapperClass: 'nti-tags-wrapper nti-tags-wrapper-index',
                 tagClass: 'nti-tag',
             }
@@ -17,10 +17,9 @@
         props: ['resourceName', 'field'],
         mounted() {
             vm = this;
-            this.newField = this.field;
-            let items = this.field.value || this.field.displayedAs;
+            let items = this.fieldLabel;
 
-            if (items) {
+            if (items instanceof Array && items.length) {
                 items.forEach(function (item, index) {
                     // Backward compatibility in case tags are stored as object
                     let label = (typeof item === "object" && item.hasOwnProperty('text')) ? item.text : item;

--- a/resources/js/components/IndexField.vue
+++ b/resources/js/components/IndexField.vue
@@ -10,7 +10,7 @@
             return {
                 tags: '',
                 fieldLabel: '',
-                tagsWrapperClass: 'nti-tags-wrapper',
+                tagsWrapperClass: 'nti-tags-wrapper nti-tags-wrapper-index',
                 tagClass: 'nti-tag',
             }
         },
@@ -18,9 +18,9 @@
         mounted() {
             vm = this;
             this.newField = this.field;
+            let items = this.field.value || this.field.displayedAs;
 
-            if (this.field.value) {
-                let items = this.field.value;
+            if (items) {
                 items.forEach(function (item, index) {
                     // Backward compatibility in case tags are stored as object
                     let label = (typeof item === "object" && item.hasOwnProperty('text')) ? item.text : item;

--- a/resources/sass/field.scss
+++ b/resources/sass/field.scss
@@ -1,13 +1,19 @@
 /**
 * Nova Field styles
 */
+.nti-tags-wrapper-index {
+    display: flex;
+    flex-wrap: wrap;
+    width: 25vw;
+}
+
 .nti-tags-wrapper {
     margin-bottom: -5px;
 
     .nti-tag {
         display: inline-block;
         margin: 2px;
-        color: rgba(var(--colors-white),var(--tw-text-opacity)) !important;
+        color: rgba(var(--colors-white)) !important;
         background-color: rgba(var(--colors-primary-500),var(--tw-bg-opacity)) !important;
         padding: 3px 4px !important;
         border-radius: 0.2rem !important;
@@ -17,7 +23,7 @@
     }
 
     .dark & .nti-tag {
-        color: rgba(var(--colors-gray-900),var(--tw-text-opacity)) !important;
+        color: rgba(var(--colors-slate-900)) !important;
     }
 }
 
@@ -35,20 +41,20 @@
     --tw-text-opacity: 1 !important;
     font-size: .875rem !important;
     background-color: rgba(var(--colors-white),var(--tw-bg-opacity)) !important;
-    border-color: rgba(var(--colors-gray-300),var(--tw-border-opacity));
+    border-color: rgba(var(--colors-slate-300),var(--tw-border-opacity));
     border-radius: 0.25rem !important;
     border-width: 1px !important;
-    color: rgba(var(--colors-gray-600),var(--tw-text-opacity)) !important;
+    color: rgba(var(--colors-slate-600)) !important;
     padding-left: 0.75rem !important;
     padding-right: 0.75rem !important;
     box-sizing: border-box !important;
     line-height: normal !important;
 }
 .dark .ti-input, .dark .ti-new-tag-input {
-    --tw-ring-color: rgba(var(--colors-gray-700),var(--tw-ring-opacity)) !important;
-    background-color: rgba(var(--colors-gray-900),var(--tw-bg-opacity)) !important;
-    color: rgba(var(--colors-gray-400),var(--tw-text-opacity)) !important;
-    border-color: rgba(var(--colors-gray-700),var(--tw-border-opacity)) !important;
+    --tw-ring-color: rgba(var(--colors-slate-700),var(--tw-ring-opacity)) !important;
+    background-color: rgba(var(--colors-slate-900),var(--tw-bg-opacity)) !important;
+    color: rgba(var(--colors-slate-400)) !important;
+    border-color: rgba(var(--colors-slate-700),var(--tw-border-opacity)) !important;
 }
 .ti-tag {
     font-size: .875rem !important;
@@ -58,12 +64,12 @@
     border-radius: 0.2rem !important;
 
     &.ti-valid {
-        color: rgba(var(--colors-white),var(--tw-text-opacity)) !important;
+        color: rgba(var(--colors-white)) !important;
         background-color: rgba(var(--colors-primary-500),var(--tw-bg-opacity)) !important;
     }
 
     .dark &.ti-valid {
-        color: rgba(var(--colors-gray-900),var(--tw-text-opacity)) !important;
+        color: rgba(var(--colors-slate-900)) !important;
     }
 
     &.ti-deletion-mark {
@@ -75,11 +81,11 @@
     .ti-item {
         &.ti-selected-item {
             background-color: var(--colors-primary-500) !important;
-            color: rgba(var(--colors-white),var(--tw-text-opacity)) !important;
+            color: rgba(var(--colors-white)) !important;
         }
 
         .dark &.ti-selected-item {
-            color: rgba(var(--colors-gray-900),var(--tw-text-opacity)) !important;
+            color: rgba(var(--colors-slate-900)) !important;
         }
     }
 }

--- a/resources/sass/field.scss
+++ b/resources/sass/field.scss
@@ -4,7 +4,6 @@
 .nti-tags-wrapper-index {
     display: flex;
     flex-wrap: wrap;
-    width: 25vw;
 }
 
 .nti-tags-wrapper {


### PR DESCRIPTION
**Note:** This does not include an updated dist build let me know if you require me to do it

In separate 4.x Nova releases they firstly broke the styling of tags on dark mode, and then In a later released a new field attribute called `displayedAs` which made the tags display like so:

![image](https://user-images.githubusercontent.com/20278756/194325656-9fab1e0f-5394-43b8-a8fb-3627fc2b186c.png)

This PR fixes that so that the tags display as expected both with css and also adding support for the `displayedAs` attribute:

**Index**
![image](https://user-images.githubusercontent.com/20278756/194326663-b4aae1d1-268e-4828-930e-b979449855aa.png)

**Detail**
![image](https://user-images.githubusercontent.com/20278756/194326809-d8a72a37-da22-46f6-a2d3-a37578a075cd.png)
